### PR TITLE
Optimize enumerators to structs to avoid boxing

### DIFF
--- a/JiksLib.Core.Test/Collections/ArrayLinkedListTests.cs
+++ b/JiksLib.Core.Test/Collections/ArrayLinkedListTests.cs
@@ -147,7 +147,7 @@ namespace JiksLib.Test.Collections
             // Arrange
             var list = new ArrayLinkedList<int>();
             int slot1 = list.AddLast(1);
-            list.AddLast(3);
+            int slot2 = list.AddLast(3);
 
             // Act
             int newSlot = list.AddAfter(slot1, 2);
@@ -156,7 +156,11 @@ namespace JiksLib.Test.Collections
             Assert.That(list.Count, Is.EqualTo(3));
             Assert.That(list.Get(newSlot, out int nextSlot, out int prevSlot), Is.EqualTo(2));
             Assert.That(prevSlot, Is.EqualTo(slot1)); // 应该在slot1之后
-            Assert.That(nextSlot, Is.Not.EqualTo(-1)); // 应该指向原来的第二个元素
+            Assert.That(nextSlot, Is.EqualTo(slot2)); // 应该指向原来的第二个元素
+
+            // 验证原来的第二个元素的前驱已更新为新槽位
+            Assert.That(list.Get(slot2, out int next2, out int prev2), Is.EqualTo(3));
+            Assert.That(prev2, Is.EqualTo(newSlot));
         }
 
         [Test]
@@ -181,7 +185,7 @@ namespace JiksLib.Test.Collections
         {
             // Arrange
             var list = new ArrayLinkedList<int>();
-            list.AddLast(1);
+            int slot1 = list.AddLast(1);
             int slot2 = list.AddLast(3);
 
             // Act
@@ -191,7 +195,11 @@ namespace JiksLib.Test.Collections
             Assert.That(list.Count, Is.EqualTo(3));
             Assert.That(list.Get(newSlot, out int nextSlot, out int prevSlot), Is.EqualTo(2));
             Assert.That(nextSlot, Is.EqualTo(slot2)); // 应该在slot2之前
-            Assert.That(prevSlot, Is.Not.EqualTo(-1)); // 应该指向原来的第一个元素
+            Assert.That(prevSlot, Is.EqualTo(slot1)); // 应该指向原来的第一个元素
+
+            // 验证原来的第一个元素的后继已更新为新槽位
+            Assert.That(list.Get(slot1, out int next1, out int prev1), Is.EqualTo(1));
+            Assert.That(next1, Is.EqualTo(newSlot));
         }
 
         [Test]
@@ -218,9 +226,14 @@ namespace JiksLib.Test.Collections
             list.AddLast(3);
             list.AddLast(2);
 
-            // Act & Assert
-            Assert.That(list.FindSlot(2), Is.EqualTo(list.FirstSlot + 1)); // 第一个2的位置
-            Assert.That(list.FindSlot(4), Is.EqualTo(-1));
+            // Act
+            int slotIndex = list.FindSlot(2);
+            int notFoundSlotIndex = list.FindSlot(4);
+
+            // Assert
+            Assert.That(slotIndex, Is.Not.EqualTo(-1));
+            Assert.That(list.Get(slotIndex, out _, out _), Is.EqualTo(2)); // 槽位中的值应为2
+            Assert.That(notFoundSlotIndex, Is.EqualTo(-1));
         }
 
         [Test]
@@ -233,9 +246,15 @@ namespace JiksLib.Test.Collections
             list.AddLast(3);
             list.AddLast(2);
 
-            // Act & Assert
-            Assert.That(list.FindLastSlot(2), Is.EqualTo(list.LastSlot)); // 最后一个2的位置
-            Assert.That(list.FindLastSlot(4), Is.EqualTo(-1));
+            // Act
+            int slotIndex = list.FindLastSlot(2);
+            int notFoundSlotIndex = list.FindLastSlot(4);
+
+            // Assert
+            Assert.That(slotIndex, Is.Not.EqualTo(-1));
+            Assert.That(list.Get(slotIndex, out _, out _), Is.EqualTo(2)); // 槽位中的值应为2
+            Assert.That(slotIndex, Is.EqualTo(list.LastSlot)); // 在这个测试数据中，最后一个2就是最后一个元素
+            Assert.That(notFoundSlotIndex, Is.EqualTo(-1));
         }
 
         [Test]

--- a/JiksLib.Core.Test/Collections/DequeTests.cs
+++ b/JiksLib.Core.Test/Collections/DequeTests.cs
@@ -371,6 +371,131 @@ namespace JiksLib.Test.Collections
             Assert.That(list, Is.Empty);
         }
 
+        #region Enumerator Behavior Tests
+
+        [Test]
+        public void DequeEnumerator_IsValueType()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+
+            // Act
+            var enumerator = deque.GetEnumerator();
+
+            // Assert
+            Assert.That(enumerator.GetType().IsValueType, Is.True, "Enumerator should be a value type (struct)");
+        }
+
+        [Test]
+        public void DequeEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+            var enumerator = deque.GetEnumerator();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void DequeEnumerator_CurrentAfterEnumeration_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+            var enumerator = deque.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void DequeEnumerator_MoveNextAfterEnumeration_ReturnsFalse()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+            var enumerator = deque.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.That(enumerator.MoveNext(), Is.False);
+            Assert.That(enumerator.MoveNext(), Is.False); // Multiple calls should still return false
+        }
+
+        [Test]
+        public void DequeEnumerator_Reset_WorksCorrectly()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+            var enumerator = deque.GetEnumerator();
+            var firstPass = new List<int>();
+            while (enumerator.MoveNext())
+            {
+                firstPass.Add(enumerator.Current);
+            }
+
+            // Act
+            enumerator.Reset();
+            var secondPass = new List<int>();
+            while (enumerator.MoveNext())
+            {
+                secondPass.Add(enumerator.Current);
+            }
+
+            // Assert
+            Assert.That(secondPass, Is.EqualTo(firstPass));
+        }
+
+        [Test]
+        public void DequeEnumerator_Dispose_DoesNotThrow()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+            var enumerator = deque.GetEnumerator();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+            // Dispose should be callable multiple times
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+        }
+
+        [Test]
+        public void DequeEnumerator_BoxingNotOccurred_WhenUsingConcreteType()
+        {
+            // Arrange
+            var deque = new Deque<int>();
+            deque.Add(1);
+            deque.Add(2);
+            deque.Add(3);
+
+            // Act
+            var enumerator = deque.GetEnumerator();
+
+            // Assert - If enumerator is a struct, assigning to object causes boxing
+            // We can verify that the type is a value type
+            Assert.That(enumerator.GetType().IsValueType, Is.True);
+        }
+
+        #endregion
+
         [Test]
         public void StressTest_CircularBufferBehavior()
         {

--- a/JiksLib.Core.Test/Collections/IntRangeTests.cs
+++ b/JiksLib.Core.Test/Collections/IntRangeTests.cs
@@ -340,6 +340,111 @@ namespace JiksLib.Test.Collections
 
         #endregion
 
+        #region Enumerator Behavior Tests
+
+        [Test]
+        public void Enumerator_IsValueType()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+
+            // Act
+            var enumerator = range.GetEnumerator();
+
+            // Assert
+            Assert.That(enumerator.GetType().IsValueType, Is.True, "Enumerator should be a value type (struct)");
+        }
+
+        [Test]
+        public void Enumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+            var enumerator = range.GetEnumerator();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void Enumerator_CurrentAfterEnumeration_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+            var enumerator = range.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void Enumerator_MoveNextAfterEnumeration_ReturnsFalse()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+            var enumerator = range.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.That(enumerator.MoveNext(), Is.False);
+            Assert.That(enumerator.MoveNext(), Is.False); // Multiple calls should still return false
+        }
+
+        [Test]
+        public void Enumerator_Reset_WorksCorrectly()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+            var enumerator = range.GetEnumerator();
+            var firstPass = new System.Collections.Generic.List<int>();
+            while (enumerator.MoveNext())
+            {
+                firstPass.Add(enumerator.Current);
+            }
+
+            // Act
+            enumerator.Reset();
+            var secondPass = new System.Collections.Generic.List<int>();
+            while (enumerator.MoveNext())
+            {
+                secondPass.Add(enumerator.Current);
+            }
+
+            // Assert
+            Assert.That(secondPass, Is.EqualTo(firstPass));
+        }
+
+        [Test]
+        public void Enumerator_Dispose_DoesNotThrow()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+            var enumerator = range.GetEnumerator();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+            // Dispose should be callable multiple times
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+        }
+
+        [Test]
+        public void Enumerator_BoxingNotOccurred_WhenUsingConcreteType()
+        {
+            // Arrange
+            var range = new IntRange(1, true, 3, true);
+
+            // Act
+            var enumerator = range.GetEnumerator();
+
+            // Assert - If enumerator is a struct, assigning to object causes boxing
+            // We can verify that the type is a value type (already tested in Enumerator_IsValueType)
+            // Additional check: ensure it's not already boxed by checking GetType()
+            Assert.That(enumerator.GetType().IsValueType, Is.True);
+        }
+
+        #endregion
+
         #region IReadOnlyCollection Implementation Tests
 
         [Test]

--- a/JiksLib.Core.Test/Collections/MultiDictionaryTests.cs
+++ b/JiksLib.Core.Test/Collections/MultiDictionaryTests.cs
@@ -798,6 +798,118 @@ namespace JiksLib.Test.Collections
             Assert.That(pairs.Any(p => p.Key == "key1" && p.Value == 200), Is.True);
         }
 
+        #region Enumerator Behavior Tests
+
+        [Test]
+        public void MultiDictionaryEnumerator_IsValueType()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+
+            // Act
+            var enumerator = dict.GetEnumerator();
+
+            // Assert
+            Assert.That(enumerator.GetType().IsValueType, Is.True, "Enumerator should be a value type (struct)");
+        }
+
+        [Test]
+        public void MultiDictionaryEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+            var enumerator = dict.GetEnumerator();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void MultiDictionaryEnumerator_CurrentAfterEnumeration_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+            var enumerator = dict.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void MultiDictionaryEnumerator_MoveNextAfterEnumeration_ReturnsFalse()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+            var enumerator = dict.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.That(enumerator.MoveNext(), Is.False);
+            Assert.That(enumerator.MoveNext(), Is.False); // Multiple calls should still return false
+        }
+
+        [Test]
+        public void MultiDictionaryEnumerator_Reset_ThrowsNotSupportedException()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+            var enumerator = dict.GetEnumerator();
+
+            // Act & Assert - MultiDictionary enumerator does not support Reset
+            Assert.Throws<NotSupportedException>(() => enumerator.Reset());
+        }
+
+        [Test]
+        public void MultiDictionaryEnumerator_Dispose_DoesNotThrow()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+            var enumerator = dict.GetEnumerator();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+            // Dispose should be callable multiple times
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+        }
+
+        [Test]
+        public void MultiDictionaryEnumerator_BoxingNotOccurred_WhenUsingConcreteType()
+        {
+            // Arrange
+            var dict = new MultiDictionary<string, int>();
+            dict.Add("key1", 100);
+            dict.Add("key1", 200);
+            dict.Add("key2", 300);
+
+            // Act
+            var enumerator = dict.GetEnumerator();
+
+            // Assert - If enumerator is a struct, assigning to object causes boxing
+            // We can verify that the type is a value type
+            Assert.That(enumerator.GetType().IsValueType, Is.True);
+        }
+
+        #endregion
+
         [Test]
         public void Remove_KeyWithMultipleValues_RemovesAllValuesAndDecreasesCountCorrectly()
         {

--- a/JiksLib.Core.Test/Collections/MultiHashSetTests.cs
+++ b/JiksLib.Core.Test/Collections/MultiHashSetTests.cs
@@ -309,6 +309,118 @@ namespace JiksLib.Test.Collections
             Assert.That(items.Where(x => x == 3).Count(), Is.EqualTo(2));
         }
 
+        #region Enumerator Behavior Tests
+
+        [Test]
+        public void MultiHashSetEnumerator_IsValueType()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+
+            // Act
+            var enumerator = set.GetEnumerator();
+
+            // Assert
+            Assert.That(enumerator.GetType().IsValueType, Is.True, "Enumerator should be a value type (struct)");
+        }
+
+        [Test]
+        public void MultiHashSetEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+            var enumerator = set.GetEnumerator();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void MultiHashSetEnumerator_CurrentAfterEnumeration_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+            var enumerator = set.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => { var _ = enumerator.Current; });
+        }
+
+        [Test]
+        public void MultiHashSetEnumerator_MoveNextAfterEnumeration_ReturnsFalse()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+            var enumerator = set.GetEnumerator();
+            while (enumerator.MoveNext()) { }
+
+            // Act & Assert
+            Assert.That(enumerator.MoveNext(), Is.False);
+            Assert.That(enumerator.MoveNext(), Is.False); // Multiple calls should still return false
+        }
+
+        [Test]
+        public void MultiHashSetEnumerator_Reset_ThrowsNotSupportedException()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+            var enumerator = set.GetEnumerator();
+
+            // Act & Assert - MultiHashSet enumerator does not support Reset
+            Assert.Throws<NotSupportedException>(() => enumerator.Reset());
+        }
+
+        [Test]
+        public void MultiHashSetEnumerator_Dispose_DoesNotThrow()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+            var enumerator = set.GetEnumerator();
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+            // Dispose should be callable multiple times
+            Assert.DoesNotThrow(() => enumerator.Dispose());
+        }
+
+        [Test]
+        public void MultiHashSetEnumerator_BoxingNotOccurred_WhenUsingConcreteType()
+        {
+            // Arrange
+            var set = new MultiHashSet<string>();
+            set.Add("a");
+            set.Add("b");
+            set.Add("a");
+
+            // Act
+            var enumerator = set.GetEnumerator();
+
+            // Assert - If enumerator is a struct, assigning to object causes boxing
+            // We can verify that the type is a value type
+            Assert.That(enumerator.GetType().IsValueType, Is.True);
+        }
+
+        #endregion
+
         [Test]
         public void CustomComparer_RespectedInOperations()
         {

--- a/JiksLib.Core/Collections/BidirectionalDictionary.cs
+++ b/JiksLib.Core/Collections/BidirectionalDictionary.cs
@@ -287,6 +287,8 @@ namespace JiksLib.Collections
         IEnumerator IEnumerable.GetEnumerator() =>
             ((IEnumerable)sequential).GetEnumerator();
 
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() =>
+            sequential.GetEnumerator();
 
         BidirectionalDictionary(
             Dictionary<TKey, TValue> sequential,


### PR DESCRIPTION
Convert IEnumerator implementations from yield return to struct enumerators in IntRange, Deque, MultiHashSet, and MultiDictionary to eliminate boxing overhead in foreach loops.